### PR TITLE
:bug: fix edit state title & desc when change category

### DIFF
--- a/src/components/category/CategoryCard.js
+++ b/src/components/category/CategoryCard.js
@@ -100,6 +100,8 @@ export default function CategoryCard(props) {
   }
 
   const handleClickEdit = e => {
+    setEditableTitle(title)
+    setEditableDesc(description)
     setIsEditable(true)
   }
 


### PR DESCRIPTION
## 버그 수정

* 카드 수정 상태일 때 카테고리 바꾸면 해당 인덱스 카드 수정 상태 눌렀을 때 전에 수정 상태였던 title, description이 나오는 버그 수정