### PR TITLE
Hotfix/api

### DIFF
--- a/src/commons/apis/alarm.js
+++ b/src/commons/apis/alarm.js
@@ -3,37 +3,49 @@ import queryData from '../queryData'
 import { getQueryParams, getDashQueryParams } from '../quryParam'
 
 const alarmAPI = {
-  get : () => {
+  get : (alarmInfo) => {
     try {
-      const alarmRead = queryData["alarmRead"]
+      const alarmReadeKeys = Object.keys(queryData["alarmRead"])
+      const alarmRead = {}
+      Object.entries(alarmInfo).forEach(([key, value]) => {
+        if (alarmReadeKeys.includes(key)) alarmRead[key] = value
+      })
       return axios.get(api.ALARM, alarmRead)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  write: ({ name, category, url, year, month, day, hour, minute }) => {
+  write: (alarmInfo) => {
     try {
+      const { category, url, reserved_time: { year, month, day } } = alarmInfo
       const queryParams = getQueryParams({ category, url })
       if (!queryParams) throw new Error(`category: ${category}, url: ${url} Id는 필수 입니다.`)
       else if(!year || !month || !day) throw new Error(`알람 필수 값을 넣어야 합니다. year : ${year} || month : ${month} || day : ${day}`)
-      const alarmWrite = Object.assign(queryData["alarmWrite"])
-      alarmWrite.name = name
-      alarmWrite.reserved_time = { year, month, day, hour, minute }
+      const alarmWriteKeys = Object.keys(queryData["alarmWrite"])
+      const alarmWrite = {}
+      Object.entries(alarmInfo).forEach(([key, value]) => {
+        if (alarmWriteKeys.includes(key)) alarmWrite[key] = value
+      })
       return axios.post(api.ALARM + queryParams, alarmWrite)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  remove : ({ id }) => {
+  remove : (alarmInfo) => {
     try {
+      const { id } = alarmInfo
       const dashQueryParams = getDashQueryParams([id])
       if(!dashQueryParams) throw new Error(`alarm : ${id} Id는 필수 입니다.`)
-      const alarmDelete = Object.assign(queryData["alarmDelete"])
+      const alarmDeleteKeys = Object.keys(queryData["alarmDelete"])
+      const alarmDelete = {}
+      Object.entries(alarmInfo).forEach(([key, value]) => {
+        if (alarmDeleteKeys.includes(key)) alarmDelete[key] = value
+      })
       return axios.delete(api.ALARM + dashQueryParams, alarmDelete)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   }
 }

--- a/src/commons/apis/alarmSocket.js
+++ b/src/commons/apis/alarmSocket.js
@@ -13,42 +13,51 @@ const alarmSocket = {
       if(callback && typeof callback === "function") server.onmessage = callback
       else {
         server.onmessage = function(e) {
-          const data = JSON.parse(e.data);
-          console.log(data);
-        };
+          const data = JSON.parse(e.data)
+          console.log(data)
+        }
       }
     } catch(error) {
-      console.warn(error)
+      return {error}
     }
   },
   onclose: (callback) => {
     if(callback && typeof callback === "function") server.onclose = callback
     else {
       server.onclose = function(e) {
-        console.error('Chat socket closed unexpectedly');
-      };
+        console.warn('Chat socket closed unexpectedly')
+        console.warn(e)
+      }
     }
   },
-  alarmRead: ({ id }) => {
+  alarmRead: (socketAlarmInfo) => {
     try {
-      if(!id) throw new Error("id값은 필수 입니다.")
-      const alarmReadMessage = queryData["alarmReadMessage"]
-      alarmReadMessage.alarm_id = id
+      const { alarm_id } = socketAlarmInfo
+      if(!alarm_id) throw new Error("id값은 필수 입니다.")
+      const alarmReadMessageKeys = Object.keys(queryData["alarmReadMessage"])
+      const alarmReadMessage = {}
+      Object.entries(socketAlarmInfo).forEach(([key, value]) => {
+        if (alarmReadMessageKeys.includes(key)) alarmReadMessage[key] = value
+      })
       server.send(JSON.stringify(alarmReadMessage))
     }
     catch(error) {
-      console.warn(error)
+      return {error}
     }
   },
-  alarmNoReturn: ({ id }) => {
+  alarmNoReturn: (socketAlarmInfo) => {
     try {
-      if(!id) throw new Error("id값은 필수 입니다.")
-      const alarmNoReturnMessage = queryData["alarmNoReturnMessage"]
-      alarmNoReturnMessage.alarm_id = id
+      const { alarm_id } = socketAlarmInfo
+      if(!alarm_id) throw new Error("id값은 필수 입니다.")
+      const alarmNoReturnMessageKeys = Object.keys(queryData["alarmNoReturnMessage"])
+      const alarmNoReturnMessage = {}
+      Object.entries(socketAlarmInfo).forEach(([key, value]) => {
+        if (alarmNoReturnMessageKeys.includes(key)) alarmNoReturnMessage[key] = value
+      })
       server.send(JSON.stringify(alarmNoReturnMessage))
     }
     catch(error) {
-      console.warn(error)
+      return {error}
     }
   }
 }

--- a/src/commons/apis/category.js
+++ b/src/commons/apis/category.js
@@ -3,50 +3,63 @@ import queryData from '../queryData'
 import { getDashQueryParams } from '../quryParam'
 
 const categoryAPI = {
-  get : ({ id }) => {
+  get: (categoryInfo) => {
     try {
+      const { id } = categoryInfo
       let dashQueryParams = getDashQueryParams([id])
-      const categoryRead = queryData["categoryRead"]
+      const categoryReadKeys = Object.keys(queryData["categoryRead"])
+      const categoryRead = {}
+      Object.entries(categoryInfo).forEach(([key, value]) => {
+        if (categoryReadKeys.includes(key)) categoryRead[key] = value
+      })
       return axios.get(api.CATEGORY + dashQueryParams, categoryRead)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
   
-  write : ({ name, isFavorited }) => {
+  write: (categoryInfo) => { // !! 추후에 camelCase npm install 할 지 결정
     try {
-      const categoryWrite = Object.assign(queryData["categoryWrite"])
-      categoryWrite.name = name
-      categoryWrite.is_favorited = isFavorited
+      const categoryWriteKeys = Object.keys(queryData["categoryWrite"])
+      const categoryWrite = {}
+      Object.entries(categoryInfo).forEach(([key, value]) => {
+        if (categoryWriteKeys.includes(key)) categoryWrite[key] = value
+      })
       return axios.post(api.CATEGORY, categoryWrite)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
   
-  update : ({ id, name, order, isFavorited }) => {
+  update: (categoryInfo) => { // !! 추후에 camelCase npm install 할 지 결정
     try {
+      const { id } = categoryInfo
       let dashQueryParams = getDashQueryParams([id])
-      const categoryUpdate = Object.assign(queryData["categoryUpdate"])
-      console.log('updateAPI', id, name, order, isFavorited)
       if(!dashQueryParams) throw new Error(`category : ${id} Id는 필수 입니다.`)
-      categoryUpdate.name = name
-      categoryUpdate.order = order
-      categoryUpdate.is_favorited = isFavorited
+      const categoryUpdateKeys = Object.keys(queryData["categoryUpdate"])
+      const categoryUpdate = {}
+      Object.entries(categoryInfo).forEach(([key, value]) => {
+        if (categoryUpdateKeys.includes(key)) categoryUpdate[key] = value
+      })
       return axios.patch(api.CATEGORY + dashQueryParams, categoryUpdate)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
   
-  remove : ({ id }) => {
+  remove: (categoryInfo) => {
     try {
+      const { id } = categoryInfo
       let dashQueryParams = getDashQueryParams([id])
-      const categoryDelete = Object.assign(queryData["categoryDelete"])
       if(!dashQueryParams) throw new Error(`category : ${id} Id는 필수 입니다.`)
+      const categoryDeleteKeys = Object.keys(queryData["categoryDelete"])
+      const categoryDelete = {}
+      Object.entries(categoryInfo).forEach(([key, value]) => {
+        if (categoryDeleteKeys.includes(key)) categoryDelete[key] = value
+      })
       return axios.delete(api.CATEGORY + dashQueryParams, categoryDelete)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   }
 }

--- a/src/commons/apis/link.js
+++ b/src/commons/apis/link.js
@@ -3,53 +3,66 @@ import queryData from '../queryData'
 import { getQueryParams, getDashQueryParams } from '../quryParam'
 
 const linkAPI = {
-  get : ({ category, path, title }) => {
+  get : (linkInfo) => {
     try {
+      const { category, path, title } = linkInfo
       const queryParams = getQueryParams({ category, path, title })
-      const linkRead = queryData["linkRead"]
+      const linkReadKeys = Object.keys(queryData["linkRead"])
+      const linkRead = {}
+      Object.entries(linkInfo).forEach(([key, value]) => {
+        if (linkReadKeys.includes(key)) linkRead[key] = value
+      })
       return axios.get(api.LINK + queryParams, linkRead)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
   
-  write : ({ category, path }) => {
+  write : (linkInfo) => {
     try {
+      const { category, path } = linkInfo
       if(!Array.isArray(path)) throw new Error("path는 Array type이 필수 입니다.")
       let queryParams = getQueryParams({ category })
-      const linkWrite = Object.assign(queryData["linkWrite"])
-      linkWrite.path = path
+      const linkWriteKeys = Object.keys(queryData["linkWrite"])
+      const linkWrite = {}
+      Object.entries(linkInfo).forEach(([key, value]) => {
+        if (linkWriteKeys.includes(key)) linkWrite[key] = value
+      })
       return axios.post(api.LINK + queryParams, linkWrite)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
   
-  // linkInfo : Object { id, name, order, isFavorited }
   update : (linkInfo) => {
     try {
       const { id } = linkInfo
       let dashQueryParams = getDashQueryParams([id])
       if(!dashQueryParams) throw new Error(`link : ${id} Id는 필수 입니다.`)
-      const linkUpdateKeys = Object.assign(queryData["linkUpdate"])
+      const linkUpdateKeys = Object.keys(queryData["linkUpdate"])
       const linkUpdate = {}
       Object.entries(linkInfo).forEach(([key, value]) => {
-        if (Object.getOwnPropertyNames(linkUpdateKeys).indexOf(key) > -1) linkUpdate[key] = value
+        if (linkUpdateKeys.includes(key)) linkUpdate[key] = value
       })
       return axios.patch(api.LINK + dashQueryParams, linkUpdate)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  remove : ({ id }) => {
+  remove : (linkInfo) => {
     try {
+      const { id } = linkInfo
       let dashQueryParams = getDashQueryParams([id])
       if(!dashQueryParams) throw new Error(`link : ${id} Id는 필수 입니다.`)
-      const linkDelete = Object.assign(queryData["linkDelete"])
+      const linkDeleteKeys = Object.keys(queryData["linkDelete"])
+      const linkDelete = {}
+      Object.entries(linkInfo).forEach(([key, value]) => {
+        if (linkDeleteKeys.includes(key)) linkDelete[key] = value
+      })
       return axios.delete(api.LINK + dashQueryParams, linkDelete)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   }
 }

--- a/src/commons/apis/user.js
+++ b/src/commons/apis/user.js
@@ -87,7 +87,7 @@ const userAPI = {
       Object.entries(userInfo).forEach(([key, value]) => {
         if (gLoginKeys.includes(key)) gLogin[key] = value
       })
-      return axios.post(api.G_MEMBER_LOGIN, login)
+      return axios.post(api.G_MEMBER_LOGIN, gLogin)
     } catch (error) {
       return {error}
     }

--- a/src/commons/apis/user.js
+++ b/src/commons/apis/user.js
@@ -2,77 +2,94 @@ import { axios, api } from '../http'
 import queryData from '../queryData'
 
 const userAPI = {
-  get : () => {
+  get : (userInfo) => {
     try {
-      const userRead = queryData["userRead"]
+      const userReadKeys = Object.keys(queryData["userRead"])
+      const userRead = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (userReadKeys.includes(key)) userRead[key] = value
+      })
       return axios.get(api.MEMBER, userRead)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  update: ({ username, password }) => {
+  update: (userInfo) => {
     try {
-      const userUpdate = queryData["userUpdate"]
-      userUpdate.username = username
-      userUpdate.password = password
+      const userUpdateKeys = Object.keys(queryData["userUpdate"])
+      const userUpdate = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (userUpdateKeys.includes(key)) userUpdate[key] = value
+      })
       return axios.patch(api.MEMBER, userUpdate)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  remove : () => {
+  remove : (userInfo) => {
     try {
-      const userDelete = queryData["userDelete"]
+      const userDeleteKeys = Object.keys(queryData["userDelete"])
+      const userDelete = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (userDeleteKeys.includes(key)) userDelete[key] = value
+      })
       return axios.delete(api.MEMBER, userDelete)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  nRegister: ({ email, username, password }) => {
+  nRegister: (userInfo) => {
     try {
-      const nRegister = queryData["n_register"]
-      nRegister.email = email
-      nRegister.username = username
-      nRegister.password = password
+      const nRegisterKeys = Object.keys(queryData["nRegister"])
+      const nRegister = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (nRegisterKeys.includes(key)) nRegister[key] = value
+      })
       return axios.post(api.N_MEMBER_REGISTER, nRegister)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  nLogin: ({ email, password }) => {
+  nLogin: (userInfo) => {
     try {
-      const nLogin = queryData["n_login"]
-      nLogin.email = email
-      nLogin.password = password
+      const nLoginKeys = Object.keys(queryData["nLogin"])
+      const nLogin = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (nLoginKeys.includes(key)) nLogin[key] = value
+      })
       return axios.post(api.N_MEMBER_LOGIN, nLogin)
     } catch (error) {
-      console.warn(error)
+      return {error}
     }
   },
 
-  gRegister: ({ token }) => {
+  gRegister: (userInfo) => {
     try {
-      if (!token) throw new Error(` token: ${token}은 필수 값 입니다.`)
-      const gRegister = queryData['g_register']
-      gRegister.token = token
+      const gRegisterKeys = Object.keys(queryData["gRegister"])
+      const gRegister = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (gRegisterKeys.includes(key)) gRegister[key] = value
+      })
       return axios.post(api.G_MEMBER_REGISTER, gRegister)
     } catch (error) {
-      console.warn(error);
+      return {error}
     }
   },
 
-  gLogin: ({ token }) => {
+  gLogin: (userInfo) => {
     try {
-      if(!token) throw new Error(` token: ${token}은 필수 값 입니다.`)
-      const login = queryData['g_login']
-      login.token = token
+      const gLoginKeys = Object.keys(queryData["gLogin"])
+      const gLogin = {}
+      Object.entries(userInfo).forEach(([key, value]) => {
+        if (gLoginKeys.includes(key)) gLogin[key] = value
+      })
       return axios.post(api.G_MEMBER_LOGIN, login)
     } catch (error) {
-      console.warn(error);
+      return {error}
     }
   }
 }

--- a/src/commons/queryData.js
+++ b/src/commons/queryData.js
@@ -6,7 +6,7 @@ const queryData = {
    * * /user/sign-up/
    * * Authorization: JWT 불필요
    */
-  n_register: {
+  nRegister: {
     "sign_up_type": "normal",
     "email": "",
     "username": "",
@@ -18,7 +18,7 @@ const queryData = {
    * * /user/sign-in/
    * * Authorization: JWT 불필요
    */
-  n_login: {
+  nLogin: {
     "email": "",
     "password": ""
   },
@@ -29,7 +29,7 @@ const queryData = {
    * * Authorization: JWT 불필요
    * * email, password 불필요
    */
-  g_login: {
+  gLogin: {
     "token": ""
   },
   
@@ -39,7 +39,7 @@ const queryData = {
    * * Authorization: JWT 불필요
    * * email, password 불필요
    */
-  g_register: {
+  gRegister: {
     "token": ""
   },
   

--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -4,11 +4,11 @@ import Alert from '@material-ui/lab/Alert'
 
 export default function UrlinkSnackbar(props) {
 
-  const {alertText, open, handleClose} = props
+  const {alertText, type="info", open, handleClose} = props
 
   return (
     <Snackbar open={open} autoHideDuration={2000} onClose={handleClose}>
-      <Alert elevation={6} variant="filled" severity="info">
+      <Alert elevation={6} variant="filled" severity={type}>
         {alertText}
       </Alert>
     </Snackbar>

--- a/src/components/category/CategoryCard.js
+++ b/src/components/category/CategoryCard.js
@@ -87,15 +87,18 @@ export default function CategoryCard(props) {
 
   const handleSetAlarm = date => {
     setIsReset(true)
-    writeAlarm(`${category}-${id}`,
-      category,
-      id, 
-      date.year(), 
-      date.month()+1, 
-      date.date(), 
-      date.hours(), 
-      date.minutes()
-    )
+    writeAlarm({
+      name: `${category}-${id}`,
+      category: category,
+      url: id,
+      reserved_time: {
+        year: date.year(),
+        month: date.month() + 1,
+        day: date.date(),
+        hour: date.hours(),
+        minute: date.minute()
+      }
+    })
   }
 
   const handleClickEdit = e => {

--- a/src/components/category/CategoryDrawer.js
+++ b/src/components/category/CategoryDrawer.js
@@ -598,10 +598,8 @@ export default function CategoryDrawer(props) {
 
   const handleClickDeleteSelectedCardList = () => {
     Promise.all(selectedCardList.map(card => deleteLink({ id: card.id }))).then(() => {
-      setSelectedCardList([])
       setDeleteSuccessAlert(true)
       setIsReset(true)
-    }).then(() => {
       // getLink(selectedCategoryId) // !! 이미 useEffect에서 처리
       getCategory({})
     })

--- a/src/components/category/CategoryDrawer.js
+++ b/src/components/category/CategoryDrawer.js
@@ -75,19 +75,18 @@ export default function CategoryDrawer(props) {
   const [enterOpen, setEnterOpen] = useState(false)
 
   useEffect(() => {
-      if (!selectedCategoryId && categories.length) {
-        setAddOpen(true)
-        setDeleteOpen(false)
-        setSelectedCategoryId(categories[0]?.id)
-        setSelectedCategoryTitle(categories[0]?.name)
-      } else  {
-        getLink(selectedCategoryId)
-      }
-
+    if (!selectedCategoryId && categories.length) {
+      setAddOpen(true)
+      setDeleteOpen(false)
+      setSelectedCategoryId(categories[0]?.id)
+      setSelectedCategoryTitle(categories[0]?.name)
+    } else if(selectedCategoryId) {
+      getLink({ category: selectedCategoryId })
+    }
   }, [categories, selectedCategoryId])
   
   const handleClickCategoryTitle = () => {
-    getLink(selectedCategoryId)
+    getLink({ category: selectedCategoryId })
   }
 
   const handleChangeNewCategoryTitle = (e) => {
@@ -110,7 +109,7 @@ export default function CategoryDrawer(props) {
       if (toggleAlignment === 'left') path = value
       else if (toggleAlignment === 'right') title = value
       setSearchValue(value)
-      getLink(selectedCategoryId, path, title)
+      getLink({ category: selectedCategoryId, path, title })
     }
   }
 
@@ -123,14 +122,17 @@ export default function CategoryDrawer(props) {
     } else {
       setAddOpen(true)
       setEnterOpen(false)
-      writeCategory(newCategoryTitle, false)
+      writeCategory({ name: newCategoryTitle, is_favorited: false })
       .then((res) => {
+        setNewCategoryTitle('')
         setSelectedCategoryId(res.data.id)
         setSelectedCategoryTitle(res.data.name)
-        getLink(res.data.id)
-        return getCategory()
+        return res.data
       })
-      setNewCategoryTitle('')
+      .then((res) => {
+        getLink({ category: res.id })
+        getCategory({})
+      })
     }
   }
 
@@ -164,20 +166,18 @@ export default function CategoryDrawer(props) {
   
   const deleteTab = (e) => {
     e.stopPropagation()
-    deleteCategory(selectedCategoryId)
+    deleteCategory({ id: selectedCategoryId })
     .then(() => {
       setDeleteModalOpen(false)
       setDeleteOpen(false)
       setAddOpen(true)
-      return getCategory()
+      return getCategory({})
     })
-    .then((res) => {
-      if (res.data.length === 0) {
-        return
-      }
+    .then((res) => { // * getCategory Promise
+      if (!res.data.length) return
       setSelectedCategoryId(res.data[0].id)
       setSelectedCategoryTitle(res.data[0].name)
-      getLink(res.data[0].id)
+      getLink({ category: res.data[0].id })
     })
   }
 
@@ -276,7 +276,7 @@ export default function CategoryDrawer(props) {
       if(favoritedArr.length && notFavoritedArr.length) {
         e.currentTarget.previousSibling.style.opacity = 0
       }       
-      updateCategory(id, name, order, favorited)
+      updateCategory({ id, name, order, is_favorited: favorited })
       .then(() =>  setDraggedTargetData({
         ...draggedCategoryData,
         dragFinished: true
@@ -284,7 +284,7 @@ export default function CategoryDrawer(props) {
     } else if(type === 'link') {
       e.preventDefault()
       setDragHistoryFinished(true)
-      writeLink(overedTabId, filteredLinkList)
+      writeLink({ category: overedTabId, path: filteredLinkList })
       setSelectedLinkList([])
       setDraggedHistoryList([])
     } else {
@@ -322,7 +322,7 @@ export default function CategoryDrawer(props) {
 
     if(type === 'link') {
       e.preventDefault()
-      writeLink(selectedCategoryId, filteredLinkList)
+      writeLink({ writeLink: selectedCategoryId, path: filteredLinkList })
       setDragHistoryFinished(true)
       setSelectedLinkList([])
       setDraggedHistoryList([])
@@ -335,18 +335,18 @@ export default function CategoryDrawer(props) {
   const timeId = useRef()
 
   useEffect(() => {
-
     // add Animation when finished dragging
     if(dragFinished) {
-      getCategory()
-      .then(() => draggedCategory.style.display='block')
-   
-      timeId.current = setTimeout(() => {
-        setDraggedTargetData({
-          ...draggedCategoryData,
-          dragFinished: false
-        })
-      }, 1000)  
+      getCategory({})
+      .then(() => {
+        draggedCategory.style.display='block'
+        timeId.current = setTimeout(() => {
+          setDraggedTargetData({
+            ...draggedCategoryData,
+            dragFinished: false
+          })
+        }, 1000)  
+      })
 
     } else if(dragHistoryFinished) {
       timeId.current = setTimeout(() => {
@@ -584,10 +584,14 @@ export default function CategoryDrawer(props) {
   }
 
   const handleClickDeleteSelectedCardList = () => {
-    selectedCardList.forEach(card => deleteLink(card.id, selectedCategoryId))
-    setSelectedCardList([])
-    setDeleteSuccessAlert(true)
-    setIsReset(true)
+    Promise.all(selectedCardList.map(card => deleteLink({ id: card.id }))).then(() => {
+      setSelectedCardList([])
+      setDeleteSuccessAlert(true)
+      setIsReset(true)
+    }).then(() => {
+      // getLink(selectedCategoryId) // !! 이미 useEffect에서 처리
+      getCategory({})
+    })
   }
 
   const handleDeleteSuccessAlertClose = e => {

--- a/src/components/category/CategoryTab.js
+++ b/src/components/category/CategoryTab.js
@@ -21,7 +21,7 @@ export default function CategoryTab(props) {
 
   const classes = useStyles()
 
-  const dispatch = useCategoryDispatch()
+  const { getCategory, updateCategory } = useCategoryDispatch()
   const [categoryTitle, setCategoryTitle] = useState(text)
   const [disabled, setDisabled] = useState(true)
 
@@ -60,17 +60,17 @@ export default function CategoryTab(props) {
     e.stopPropagation()
     if (e.keyCode === 13) {
       if (!e.target.value) {
-        dispatch.updateCategory(id, text, order, isFavorited)
+        updateCategory({ id, name: text, order, is_favorited: isFavorited })
           .then((_res) => {
-            dispatch.getCategory()
+            getCategory({})
             setDisabled(true)
             setSelectedCategoryTitle(text)
             setCategoryTitle(text)
         })
       } else {
-        dispatch.updateCategory(id, categoryTitle, order, isFavorited)
+        updateCategory({ id, name: categoryTitle, order, is_favorited: isFavorited })
           .then((_res) => {
-            dispatch.getCategory()
+            getCategory({})
             setDisabled(true)
             setSelectedCategoryTitle(categoryTitle)
           })

--- a/src/components/popover/AlarmPopover.js
+++ b/src/components/popover/AlarmPopover.js
@@ -9,7 +9,7 @@ import Avatar from '@material-ui/core/Avatar'
 import ImageIcon from '@material-ui/icons/Image'
 import CloseIcon from '@material-ui/icons/Close'
 import useStyles from './styles/AlarmPopover'
-import linkListEmptyIcon from '../../images/group-10.png'
+import linkListEmptyIcon from '../../images/logo/logo32.png'
 /*
  * id: 15
  * name: "test"
@@ -27,12 +27,12 @@ export default function AlarmPopover(props) {
   const {alarmList, onAlarmRead, onNoReturnAlarm} = props
 
   const handleClickAlarm = alarm => e => {
-    onAlarmRead(alarm.id)
+    onAlarmRead({ alarm_id: alarm.id })
     window.open(alarm.url_path)
   }
 
   const handleDeleteAlarm = id => e => {
-    onNoReturnAlarm(id)
+    onNoReturnAlarm({ alarm_id: id })
   }
 
   return (
@@ -41,13 +41,13 @@ export default function AlarmPopover(props) {
        {alarmList.map((alarm) =>
          <ListItem key={alarm.id} button 
            onClick={handleClickAlarm(alarm)}
-           style={alarm.alarm_has_read ? {width:'100%', backgroundColor: '#ecf2f0'} : {width:'100%', backgroundColor: 'white'}}
+           style={alarm.alarm_has_read ? {width:'100%', backgroundColor: '#e9ecef'} : {width:'100%', backgroundColor: 'white'}}
          >
           <ListItemAvatar>
             <Avatar className={classes.avatar}>
               {
-                alarm.url_favicon_path 
-                ? <img className={classes.img} src={alarm.url_favicon_path} alt="url-favicon"/> 
+                alarm.url_image_path 
+                ? <img className={classes.img} src={alarm.url_image_path} alt="url-favicon"/> 
                 : <ImageIcon />
               }
             </Avatar>

--- a/src/components/popover/AlarmPopover.js
+++ b/src/components/popover/AlarmPopover.js
@@ -27,12 +27,12 @@ export default function AlarmPopover(props) {
   const {alarmList, onAlarmRead, onNoReturnAlarm} = props
 
   const handleClickAlarm = alarm => e => {
-    onAlarmRead({ alarm_id: alarm.id })
+    onAlarmRead({ alarm_id: alarm.id, action: "read" })
     window.open(alarm.url_path)
   }
 
   const handleDeleteAlarm = id => e => {
-    onNoReturnAlarm({ alarm_id: id })
+    onNoReturnAlarm({ alarm_id: id, action: "done" })
   }
 
   return (

--- a/src/containers/category/CategoryContainer.js
+++ b/src/containers/category/CategoryContainer.js
@@ -100,14 +100,12 @@ export default function CategoryContainer() {
       const errorMsg = error.hasOwnProperty("response") ? error.response.data.message : error.message
       setAlerType("error")
       setAlertText(errorMsg)
-      // console.warn(errorMsg)
     }
   }
 
   // * 전체 링크 리스트 가져오기 => setLink
   const getLink = async (linkInfo) => {
     try {
-      console.trace(linkInfo)
       const response = await linkAPI.get(linkInfo)
       if (response.hasOwnProperty("error")) throw response.error
       setLink([...response.data])

--- a/src/contexts/ProfileContext.js
+++ b/src/contexts/ProfileContext.js
@@ -10,14 +10,16 @@ const Profile = (props) => {
   
   const [profile, setProfile] = useState({name: '', email: '', img: ''})
   useEffect(() => {
-    getUser()
+    if(!(!!profile.name)) {
+      getUser({})
       .then(res => res.data)
       .then(res => setProfile({
         name: res.username,
         email: res.email,
         img: DefaultImg
       }))
-  })
+    }
+  },[profile])
   
   return (
     <ProfileContext.Provider value={profile}>


### PR DESCRIPTION
# API Update

- api  파라미터 받는거 전 부 **`오브젝트`** 로 통일
  - queryData로 파라미터  보낸 것 중 undefind 처리 -> 전처리 유효성 검사
- Async await return **`Promise`**
- 만약 파라마터가 객체 안에 프로퍼티가 또 객체일 경우 { a: 1, b: { } } 동일하게 만들어서 보내야 한다.
  - 추후 **`spread`** 할지도 고려해 볼 필요가 있음

## API ver2.

### 코딩 스타일 통일성

- back에서는 snakeCase로 했는데 우리 코딩 스타일은 camelCase로 작성하기 때문에 코딩스타일이 통일성이 없음
- 현재는 axios 파라미터 보낼 때, snakeCase로 보냈지만, 이것을 통일성으로 맞춰야할 필요가 있다고 생각함
- 대안  
  1. 백에서 camelCase로 통일
  2.  snakeCase [npm install]

###  Promise return 통일

- category, link 
  - category에서는 모든 메소드는 단일로 처리
    - writeCategory -> then( getCategory[setStaet] ) -> Promise
  - link에서는 각 메소드에 중첩해서 처리
     - writeLink -> getLink -> then ( logic )
- 대안
  - 모든 메소드 단일로 처리 하는게 좋다고 생각이 듬
  - state는 getAPI 에서만 일괄 처리 다른건 return 받은 Promise로 직접 커스텀하는게 좋다고 생각함 
    - 예외 상황이 많기 때문에 CUD API에서 직접 state 관리 혹은 API callback 할 경우 또 다른 메서드를 만들어야 하기 때문에 pure 블럭단위로 만드는게 좋다고 생각함

### redux, redux - saga, contextAPI

- 서버통신이 점점 많아지고 복잡해 질 수록 contextAPI 패턴이 좋을지 , 리덕스가 좋을지 다시 고려해 볼 필요가 있다고 생각함

# Snackbar 

- severity type props [A]
- API 처리중 성공 및 실패 할 때 토스트로 보여줘야하경우 info, error로 type을 정해서 보여줌
- 토스트로 보여주지 않은건 console.warn으로 경고로 뜨게 함

# Bug-fix

- 드로어에서 api call 여러번 날리는 이슈들 해결

1. 프로필 -> /user 계속 호출되었음 => useEffect 두번 째 인자 배열에 profile 추가
2. 첫 렌더링 시 categoryId가 없을 때 /url 호출함 => categoryId가 없기 때문에 빈 배열 즉, 필요 없는 api call 함 
  - CategoryDrawer에 useEffect 수정함
  - :84 getLink =>else if(selectedCategoryId)
    => if !selectedCategoryId -> /url -> return []

# Help

- 카테고리 드래그앤 드랍 완료 하면 /url?category={categoryId} API call을 하는데 불필요한 콜인거 같은데 useEffect를 또 어떤식으로 분기 타야할지 명확하게 나누기가 힘듬 @anxiubin 
