### PR TITLE
fix bug: wrong key name

### DIFF
--- a/src/components/category/CategoryDrawer.js
+++ b/src/components/category/CategoryDrawer.js
@@ -333,9 +333,10 @@ export default function CategoryDrawer(props) {
     const filteredLinkList = [] 
     selectedLinkList.forEach(link => filteredLinkList.push(link.path))
 
+
     if(type === 'link') {
       e.preventDefault()
-      writeLink({ writeLink: selectedCategoryId, path: filteredLinkList })
+      writeLink({ category: selectedCategoryId, path: filteredLinkList })
       setDragHistoryFinished(true)
       setSelectedLinkList([])
       setDraggedHistoryList([])


### PR DESCRIPTION
머지된 내용 중 버그 발견
- key가 잘못 들어가서 드래그 드랍이 안됐음

오류:  writeLink({ writeLink: selectedCategoryId, path: filteredLinkList })
수정: writeLink({ category: selectedCategoryId, path: filteredLinkList })