### PR TITLE
API CAll reduce & Bug-fix

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,11 +5,9 @@
   "description": "url collection",
   "permissions": [
     "tabs", 
-    "activeTab",
     "<all_urls>",
     "identity",
-    "history",
-    "storage"
+    "history"
   ],
   "icons": { 
     "16": "images/logo/logo16.png",
@@ -27,7 +25,7 @@
     "persistent": false
   },
   "oauth2": {
-    "client_id": "683415540436-aimi7aksc043mre0pdj2nejtr08fkchs.apps.googleusercontent.com",
+    "client_id": "653803605818-709sm4uf5qbernulcesm3ee1kt9tr1jp.apps.googleusercontent.com",
     "scopes": [
       "https://www.googleapis.com/auth/contacts.readonly",
       "profile",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -25,7 +25,7 @@
     "persistent": false
   },
   "oauth2": {
-    "client_id": "653803605818-709sm4uf5qbernulcesm3ee1kt9tr1jp.apps.googleusercontent.com",
+    "client_id": "683415540436-aimi7aksc043mre0pdj2nejtr08fkchs.apps.googleusercontent.com",
     "scopes": [
       "https://www.googleapis.com/auth/contacts.readonly",
       "profile",

--- a/src/commons/chromeApis/history.js
+++ b/src/commons/chromeApis/history.js
@@ -34,7 +34,7 @@ const historyAPI = {
           let prevDate = ""
           historyItemList.map(function (historyItem) {
             const url = document.createElement('a')
-            let curDate = new Date(historyItem.lastVisitTime).toLocaleDateString();
+            let curDate = new Date(historyItem.lastVisitTime).toLocaleDateString()
             url.href = historyItem.url
             historyItem.hostName = url.hostname
             historyItem.favicon = `https://www.google.com/s2/favicons?domain=${url.hostname}`
@@ -45,10 +45,6 @@ const historyAPI = {
             else historyItem.first = false
             return historyItem
           })
-          // console.log("maxResults",maxResults)
-          // console.log("startTime",new Date(startTime))
-          // console.log("endTime",new Date(endTime))
-          // console.log("historyItemList.length",historyItemList.length)
           if (callback && typeof (callback) === "function") callback(historyItemList)
           else console.log(historyItemList)
         }

--- a/src/commons/queryData.js
+++ b/src/commons/queryData.js
@@ -7,7 +7,7 @@ const queryData = {
    * * Authorization: JWT 불필요
    */
   nRegister: {
-    "sign_up_type": "normal",
+    "sign_up_type": "", // * (normal default [server])
     "email": "",
     "username": "",
     "password": ""
@@ -53,14 +53,14 @@ const queryData = {
   
   /**
    * * 회원정보 조회 GET
-   * * user/{id}/
+   * * user/{userId}/ (option)
    * * JWT 필요
    */
   userRead: {},
 
   /**
    * * 회원정보 부분 수정 PATCH
-   * * user/{id}/
+   * * user/{userId}/ (option)
    * * JWT 필요
    */
   userUpdate: {
@@ -72,7 +72,7 @@ const queryData = {
   
   /**
    * * 회원정보 삭제 DELETE
-   * * user/{id}/
+   * * user/{userId}/ (option)
    * * JWT 필요
    */
   userDelete: {},
@@ -115,7 +115,7 @@ const queryData = {
   /**
  * * 카테고리 리스트 조회 GET
  * * category/ -> list
- * * category/{id}/ -> partical
+ * * category/{categoryId}/
  * * JWT 필요
  */
   categoryRead: {},
@@ -132,7 +132,7 @@ const queryData = {
   
   /**
  * * 카테고리 수정 PATCH
- * * category/{id}/
+ * * category/{categoryId}/
  * * JWT 필요
  */
   categoryUpdate: {
@@ -180,7 +180,7 @@ const queryData = {
 
   /**
    * * URL 삭제 DELETE
-   * * url/{id}/
+   * * url/{urlId}/
    * * JWT 필요
    */
   linkDelete: {},
@@ -226,7 +226,7 @@ const queryData = {
    */
   alarmReadMessage: {
     "alarm_id": "",
-    "action": "read"
+    "action": "" // * read
   },
 
   /**
@@ -235,7 +235,7 @@ const queryData = {
    */
   alarmNoReturnMessage: {
     "alarm_id": "",
-    "action": "done"
+    "action": "" // * done
   }
   
   // ****************** ALRAM - - SOCKET - END *****************//

--- a/src/components/category/CategoryDrawer.js
+++ b/src/components/category/CategoryDrawer.js
@@ -137,11 +137,8 @@ export default function CategoryDrawer(props) {
         setNewCategoryTitle('')
         setSelectedCategoryId(res.data.id)
         setSelectedCategoryTitle(res.data.name)
-        return res.data
-      })
-      .then((res) => {
-        getLink({ category: res.id })
         getCategory({})
+        return res.data
       })
     }
   }

--- a/src/containers/LoginContainer.js
+++ b/src/containers/LoginContainer.js
@@ -29,7 +29,6 @@ export default function LoginContainer() {
       const gLogin = userAPI.gLogin({token})
       if(gLogin) {
         gLogin.then(res => {
-          console.log("ss", res)
           auth.setAccessToken(res.data.token)
           window.location.href = "/index.html"
         })

--- a/src/containers/category/CategoryContainer.js
+++ b/src/containers/category/CategoryContainer.js
@@ -119,15 +119,16 @@ export default function CategoryContainer() {
   // * 링크 작성 => getLink, getCategory
   const writeLink = async (linkInfo) => {
     try {
-      const { category } = linkInfo
+      // const { category } = linkInfo
       const response = await linkAPI.write(linkInfo)
       if (response.hasOwnProperty("error")) throw response.error
-      await getLink({category})
-      await getCategory({})
+      // await getLink({category})
+      // await getCategory({})
       return response
     } catch (error) {
       const errorMsg = error.hasOwnProperty("response") ? error.response.data.message : error.message
-      console.warn(errorMsg)
+      setAlerType("error")
+      setAlertText(errorMsg)
     }
   }
 
@@ -248,8 +249,6 @@ export default function CategoryContainer() {
   }
 
   useEffect(() => {
-    getCategory({})
-
     // * SOCKET CONNECTION => setAlarmList
     alarmSocket.onmessage(function(e) {
       const { message, status } = JSON.parse(e.data)
@@ -265,7 +264,7 @@ export default function CategoryContainer() {
   return (
     <CategoryStateContext.Provider value={categoryState}>
       <CategoryDispatchContext.Provider value={categoryDispatch}>
-        <LinkStateContext.Provider value={linkState}>
+        <LinkStateContext.Provider value={[linkState, setLink]}>
           <LinkDispatchContext.Provider value={linkDispatch}>
             <CategoryDrawer {...props}/>
             <Snackbar open={alertText ? true : false}

--- a/src/containers/category/CategoryContainer.js
+++ b/src/containers/category/CategoryContainer.js
@@ -259,6 +259,7 @@ export default function CategoryContainer() {
         setAlarmList(message)
       }
     })
+    alarmSocket.onclose()
   },[])
 
   return (


### PR DESCRIPTION
# API CALL 이슈

1. 페이지 첫 로딩 시 /url을 두 번 호출 이슈 해결
- CategoryDrawer.js :78 line 참조

```
/verify
/category
/url/categoryId={categoryId}
/url/categoryId={categoryId}
```

2. 카테고리 생성 시 /category, /url 두 번 호출 이슈 해결
- CategoryDrawer.js :136line 참조

```
/category
/url/categoryId={categoryId}
/category
/url/categoryId={categoryId}
```


3. 히스토리에서 카테고리에 드로어 할 때 /url/categoryId={selectedCategoryId}를 호출
- CategoryDrawer.js :360 line 참조

- 해당 드로어 영역의 targetCategory가 selectedCategory와 다를 수 있기 때문에 selectedCategoryId === targetCategoryId를 비교하여 getLink를 호출

4. 웹 소켓 접속 에러 handshake error => 501 error code 1006
![image](https://user-images.githubusercontent.com/31876632/86515541-971cd180-be54-11ea-8de5-a6fff09f12fa.png)

- onClose에 setTimeout으로 재 접속 요청 (2초마다)
- 토큰은 이미 API에서 다시 refresh하기 때문에 따로 refresh 하지 않았지만, 변수가 생기면 refreshToken 발급 

# Bug-fix

- 모든 카테고리를 삭제하고 난 후, 카드가 그대로 나타는 버그 해결
  - useLinkState -> setLink 불러옴

 # 추가 사항

- 카테고리가 없는 상태에서 드로어 했을 때, SnakAlert 띄움
- manifest permissions 필요없는 권한 삭제
